### PR TITLE
Fix CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 8
+          node-version: 18
           cache: npm
       - name: Install Dependencies
         run: npm ci
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 8
+          node-version: 18
           cache: npm
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Fixes the test job. The default blueprint was using `./node_modules/.bin/ember` as the path to Ember, but that doesn't work in a monorepo. This fix uses `npx ember` instead.