### PR TITLE
Support embroider's `strictEmberSource` option

### DIFF
--- a/.changeset/friendly-elephants-tell.md
+++ b/.changeset/friendly-elephants-tell.md
@@ -1,0 +1,5 @@
+---
+'ember-provide-consume-context': minor
+---
+
+Support `staticEmberSource`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ having to pass arguments at each level (i.e. no prop drilling).
 ember install ember-provide-consume-context
 ```
 
+### Usage with `staticEmberSource`
+
+If you're using this addon with embroider's `staticEmberSource` enabled, you will need to configure embroider's macros for this addon to work.
+
+```
+// ember-cli-build.js
+
+let app = new EmberApp(defaults, {
+  '@embroider/macros': {
+    setConfig: {
+      'ember-provide-consume-context': {
+        staticEmberSource: true
+      },
+    },
+  },
+});
+```
+
 ## Usage
 ### Context providers
 Data can be provided to all of a component's descendants in one of two ways:

--- a/ember-provide-consume-context/addon-main.cjs
+++ b/ember-provide-consume-context/addon-main.cjs
@@ -1,4 +1,19 @@
 'use strict';
 
 const { addonV1Shim } = require('@embroider/addon-shim');
-module.exports = addonV1Shim(__dirname);
+const shimmed = addonV1Shim(__dirname);
+const embroiderHooks = {
+  options: {
+    '@embroider/macros': {
+      setOwnConfig: {
+        staticEmberSource: false,
+      },
+    },
+  },
+
+  config() {
+    return this.options['@embroider/macros']['setOwnConfig'];
+  },
+};
+
+module.exports = Object.assign({}, shimmed, embroiderHooks);

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -117,6 +117,7 @@
     "version": 2,
     "type": "addon",
     "main": "addon-main.cjs",
+    "build": "addon-main.cjs",
     "app-js": {
       "./components/context-consumer.js": "./dist/_app_/components/context-consumer.js",
       "./components/context-provider.js": "./dist/_app_/components/context-provider.js",

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",
+    "@embroider/macros": "^1.13.3",
     "@glimmer/component": "^1.1.2"
   },
   "devDependencies": {

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -34,6 +34,7 @@
     "declarations",
     "dist"
   ],
+  "main": "addon-main.cjs",
   "scripts": {
     "build": "concurrently 'npm:build:*'",
     "build:js": "rollup --config",
@@ -53,7 +54,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.0.0",
-    "@embroider/macros": "^1.13.3",
+    "@embroider/macros": "^1.13.4",
     "@glimmer/component": "^1.1.2"
   },
   "devDependencies": {

--- a/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
+++ b/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { overrideGlimmerRuntime } from '../-private/override-glimmer-runtime-classes';
-import { importSync } from '@embroider/macros';
+import { getGlobalConfig, importSync } from '@embroider/macros';
 
 export function initialize() {
   if ((Ember as any).__loader?.require == null) {
@@ -15,7 +15,7 @@ export function initialize() {
   try {
     glimmerRuntime = (Ember as any).__loader.require('@glimmer/runtime');
   } catch {
-    glimmerRuntime = importSync('@glimmer/runtime.js');
+    glimmerRuntime = importSync('@glimmer/runtime');
   }
   if (glimmerRuntime == null) {
     return;

--- a/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
+++ b/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
@@ -8,7 +8,6 @@ export function initialize() {
   }
 
   let glimmerRuntime;
-  console.log('own config', getOwnConfig());
   if (macroCondition((getOwnConfig() as any)?.staticEmberSource)) {
     glimmerRuntime = importSync('@glimmer/runtime.js');
   } else {

--- a/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
+++ b/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { overrideGlimmerRuntime } from '../-private/override-glimmer-runtime-classes';
-import { getGlobalConfig, importSync } from '@embroider/macros';
+import { getOwnConfig, importSync, macroCondition } from '@embroider/macros';
 
 export function initialize() {
   if ((Ember as any).__loader?.require == null) {
@@ -8,14 +8,11 @@ export function initialize() {
   }
 
   let glimmerRuntime;
-
-  // In builds with `strictEmber = false`, Ember.__loader.require will throw.
-  // In those cases, we catch the error, and try to access the runtime via the
-  // importSync macro, which will be resolved at build-time.
-  try {
+  console.log('own config', getOwnConfig());
+  if (macroCondition((getOwnConfig() as any)?.staticEmberSource)) {
+    glimmerRuntime = importSync('@glimmer/runtime.js');
+  } else {
     glimmerRuntime = (Ember as any).__loader.require('@glimmer/runtime');
-  } catch {
-    glimmerRuntime = importSync('@glimmer/runtime');
   }
   if (glimmerRuntime == null) {
     return;

--- a/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
+++ b/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
@@ -1,12 +1,22 @@
 import Ember from 'ember';
 import { overrideGlimmerRuntime } from '../-private/override-glimmer-runtime-classes';
+import { importSync } from '@embroider/macros';
 
 export function initialize() {
   if ((Ember as any).__loader?.require == null) {
     return;
   }
 
-  const glimmerRuntime = (Ember as any).__loader.require('@glimmer/runtime');
+  let glimmerRuntime;
+
+  // In builds with `strictEmber = false`, Ember.__loader.require will throw.
+  // In those cases, we catch the error, and try to access the runtime via the
+  // importSync macro, which will be resolved at build-time.
+  try {
+    glimmerRuntime = (Ember as any).__loader.require('@glimmer/runtime');
+  } catch {
+    glimmerRuntime = importSync('@glimmer/runtime.js');
+  }
   if (glimmerRuntime == null) {
     return;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26418,7 +26418,7 @@
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^4.1.0",
         "ember-page-title": "^7.0.0",
-        "ember-provide-consume-context": "^0.1.0",
+        "ember-provide-consume-context": "*",
         "ember-qunit": "^6.2.0",
         "ember-resolver": "^10.0.0",
         "ember-source": "~4.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26558,51 +26558,6 @@
         "node": "14.* || 16.* || >= 18"
       }
     },
-    "test-app/node_modules/@embroider/macros": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.4.tgz",
-      "integrity": "sha512-A6tXvfwnscx66QO0R3c2dIJwEltfsTL4ihsYjMtgP9ODCCmQlCaRlZDQYw5Drta0ER9Fj3nXntu4naV5Wt5XLA==",
-      "dependencies": {
-        "@embroider/shared-internals": "2.5.1",
-        "assert-never": "^1.2.1",
-        "babel-import-util": "^2.0.0",
-        "ember-cli-babel": "^7.26.6",
-        "find-up": "^5.0.0",
-        "lodash": "^4.17.21",
-        "resolve": "^1.20.0",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      },
-      "peerDependencies": {
-        "@glint/template": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@glint/template": {
-          "optional": true
-        }
-      }
-    },
-    "test-app/node_modules/@embroider/shared-internals": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.5.1.tgz",
-      "integrity": "sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==",
-      "dependencies": {
-        "babel-import-util": "^2.0.0",
-        "debug": "^4.3.2",
-        "ember-rfc176-data": "^0.3.17",
-        "fs-extra": "^9.1.0",
-        "js-string-escape": "^1.0.1",
-        "lodash": "^4.17.21",
-        "resolve-package-path": "^4.0.1",
-        "semver": "^7.3.5",
-        "typescript-memoize": "^1.0.1"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
     "test-app/node_modules/@tsconfig/ember": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/ember/-/ember-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.13.3",
         "@glimmer/component": "^1.1.2"
       },
       "devDependencies": {
@@ -15051,7 +15052,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26360,6 +26360,9 @@
     "test-app": {
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@embroider/macros": "^1.13.4"
+      },
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.0.1",
@@ -26445,6 +26448,51 @@
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
+      }
+    },
+    "test-app/node_modules/@embroider/macros": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.4.tgz",
+      "integrity": "sha512-A6tXvfwnscx66QO0R3c2dIJwEltfsTL4ihsYjMtgP9ODCCmQlCaRlZDQYw5Drta0ER9Fj3nXntu4naV5Wt5XLA==",
+      "dependencies": {
+        "@embroider/shared-internals": "2.5.1",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^2.0.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "test-app/node_modules/@embroider/shared-internals": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.5.1.tgz",
+      "integrity": "sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "test-app/node_modules/@tsconfig/ember": {
@@ -26700,11 +26748,35 @@
         "node": ">=4.0"
       }
     },
+    "test-app/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "test-app/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "test-app/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -26716,7 +26788,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -26727,11 +26798,18 @@
         "node": ">=10"
       }
     },
+    "test-app/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "test-app/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
-        "@embroider/macros": "^1.13.3",
+        "@embroider/macros": "^1.13.4",
         "@glimmer/component": "^1.1.2"
       },
       "devDependencies": {
@@ -141,6 +141,114 @@
         "rollup-plugin-copy": "^3.4.0",
         "typescript": "^5.0.4"
       }
+    },
+    "ember-provide-consume-context/node_modules/@embroider/macros": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.4.tgz",
+      "integrity": "sha512-A6tXvfwnscx66QO0R3c2dIJwEltfsTL4ihsYjMtgP9ODCCmQlCaRlZDQYw5Drta0ER9Fj3nXntu4naV5Wt5XLA==",
+      "dependencies": {
+        "@embroider/shared-internals": "2.5.1",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^2.0.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
+    "ember-provide-consume-context/node_modules/@embroider/shared-internals": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.5.1.tgz",
+      "integrity": "sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "ember-provide-consume-context/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "ember-provide-consume-context/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "ember-provide-consume-context/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "ember-provide-consume-context/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "ember-provide-consume-context/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "ember-provide-consume-context/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -26748,35 +26856,11 @@
         "node": ">=4.0"
       }
     },
-    "test-app/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "test-app/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "test-app/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -26788,6 +26872,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -26798,18 +26883,11 @@
         "node": ">=10"
       }
     },
-    "test-app/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "test-app/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "test-app"
       ],
       "dependencies": {
-        "@changesets/cli": "^2.26.2"
+        "@changesets/cli": "^2.26.2",
+        "@embroider/macros": "^1.13.3"
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
@@ -3039,6 +3040,33 @@
         "node": "12.* || 14.* || >= 16"
       }
     },
+    "node_modules/@embroider/core/node_modules/@embroider/macros": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
+      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "2.4.0",
+        "assert-never": "^1.2.1",
+        "babel-import-util": "^2.0.0",
+        "ember-cli-babel": "^7.26.6",
+        "find-up": "^5.0.0",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      },
+      "peerDependencies": {
+        "@glint/template": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@glint/template": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@embroider/core/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -3066,6 +3094,33 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/@embroider/core/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/core/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@embroider/core/node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -3075,13 +3130,18 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@embroider/core/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@embroider/macros": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.1.tgz",
-      "integrity": "sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==",
-      "dev": true,
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.13.3.tgz",
+      "integrity": "sha512-JUC1aHRLIN2LNy1l+gz7gWkw9JmnsE20GL3LduCzNvCAnEQpMTJhW5BUbEWqdCnAWBPte/M2ofckqBXyTZioTQ==",
       "dependencies": {
-        "@embroider/shared-internals": "2.4.0",
+        "@embroider/shared-internals": "2.5.1",
         "assert-never": "^1.2.1",
         "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -3102,11 +3162,54 @@
         }
       }
     },
+    "node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.5.1.tgz",
+      "integrity": "sha512-b+TWDBisH1p6HeTbJIO8pgu1WzfTP0ZSAlZBqjXwOyrS0ZxP1qNYRrEX+IxyzIibEFjXBxeLakiejz3DJvZX5A==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@embroider/macros/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/@embroider/macros/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3118,7 +3221,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3129,11 +3231,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/@embroider/macros/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@embroider/macros/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@embroider/shared-internals": {
       "version": "2.4.0",
@@ -3862,7 +3971,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@glint/template/-/template-1.2.0.tgz",
       "integrity": "sha512-8KsJSLyFQ7lB+ZgJeykoyCs4uw+p2+tMeoOZ1gP7JaoiBhlJOXtGwQv5qt4LGKNX1NjkMkyAYDGVzF1Psgnzhg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@handlebars/parser": {
       "version": "2.0.0",
@@ -5843,8 +5952,7 @@
     "node_modules/assert-never": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-      "dev": true
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test-app"
   ],
   "dependencies": {
-    "@changesets/cli": "^2.26.2"
+    "@changesets/cli": "^2.26.2",
+    "@embroider/macros": "^1.13.3"
   },
   "overrides": {
     "@glimmer/manager": "^0.84.3",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -28,8 +28,10 @@
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test"
   },
+  "dependencies": {
+    "@embroider/macros": "^1.13.4"
+  },
   "devDependencies": {
-    "ember-provide-consume-context": "*",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
@@ -87,6 +89,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^7.0.0",
+    "ember-provide-consume-context": "*",
     "ember-qunit": "^6.2.0",
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.0",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -29,7 +29,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "ember-provide-consume-context": "^0.1.0",
+    "ember-provide-consume-context": "*",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -28,9 +28,6 @@
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test"
   },
-  "dependencies": {
-    "@embroider/macros": "^1.13.4"
-  },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",


### PR DESCRIPTION
This adds support for embroider's [`strictEmberSource`](https://github.com/embroider-build/embroider/blob/7619120f104d3265aaa806fceea14008da4564d7/packages/compat/src/options.ts#L55) flag, which removes access to ember's internal `require`. This uses an ember macro to import the glimmer runtime via webpack instead.

Inspired by [this comment](https://github.com/embroider-build/embroider/issues/1057#issuecomment-1007802203).

- Install `@embroider/macros`
- Add macro condition to `glimmer-overrides.ts`
  - There's no way to know if this flag is turned on, so we add a custom flag to the macros config that libraries using this flag will need to set