### PR TITLE
Demonstrate simpler way to access @glimmer/runtime

### DIFF
--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -117,6 +117,7 @@
     "version": 2,
     "type": "addon",
     "main": "addon-main.cjs",
+    "externals": ["@glimmer/runtime"],
     "app-js": {
       "./components/context-consumer.js": "./dist/_app_/components/context-consumer.js",
       "./components/context-provider.js": "./dist/_app_/components/context-provider.js",

--- a/ember-provide-consume-context/rollup.config.mjs
+++ b/ember-provide-consume-context/rollup.config.mjs
@@ -16,6 +16,8 @@ export default {
   // You can augment this if you need to.
   output: addon.output(),
 
+  external: ['@glimmer/runtime'],
+
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.

--- a/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
+++ b/ember-provide-consume-context/src/initializers/glimmer-overrides.ts
@@ -1,16 +1,7 @@
-import Ember from 'ember';
 import { overrideGlimmerRuntime } from '../-private/override-glimmer-runtime-classes';
+import * as glimmerRuntime from '@glimmer/runtime';
 
 export function initialize() {
-  if ((Ember as any).__loader?.require == null) {
-    return;
-  }
-
-  const glimmerRuntime = (Ember as any).__loader.require('@glimmer/runtime');
-  if (glimmerRuntime == null) {
-    return;
-  }
-
   overrideGlimmerRuntime(glimmerRuntime);
 }
 


### PR DESCRIPTION
This is an alternative to #12.

V2 addons automatically have direct access to all the imports provided by Ember. The challenge here is that `@glimmer/runtime` is private API that isn't in Embroider's supported list, so we need to configure it explicitly.