### PR TITLE
Support multiple copies of addon

### DIFF
--- a/.changeset/chilly-clouds-sneeze.md
+++ b/.changeset/chilly-clouds-sneeze.md
@@ -1,0 +1,5 @@
+---
+"ember-provide-consume-context": minor
+---
+
+Support multiple copies of addon

--- a/ember-provide-consume-context/src/-private/decorators.ts
+++ b/ember-provide-consume-context/src/-private/decorators.ts
@@ -13,15 +13,10 @@ export function provide(contextKey: keyof ContextRegistry) {
 
     // A class can have multiple @provide decorated properties, we need to
     // merge the definitions
-    const contextsValue =
-      currentContexts != null
-        ? {
-            ...currentContexts.value,
-            [contextKey]: key,
-          }
-        : {
-            [contextKey]: key,
-          };
+    const contextsValue = {
+      ...currentContexts?.value,
+      [contextKey]: key,
+    };
 
     Object.defineProperty(target, EMBER_PROVIDE_CONSUME_CONTEXT_KEY, {
       value: contextsValue,

--- a/ember-provide-consume-context/src/-private/decorators.ts
+++ b/ember-provide-consume-context/src/-private/decorators.ts
@@ -1,22 +1,33 @@
 import type ContextRegistry from '../context-registry';
-import { DECORATED_PROPERTY_CLASSES } from './provide-consume-context-container';
+import { EMBER_PROVIDE_CONSUME_CONTEXT_KEY } from './provide-consume-context-container';
 import { getContextValue, hasContext } from './utils';
 
 export function provide(contextKey: keyof ContextRegistry) {
   return function decorator(target: any, key: string) {
-    // Track the class as having a decorated property. Later, this will be used
-    // on instances of this component to register them as context providers.
-    const currentContexts = DECORATED_PROPERTY_CLASSES.get(target.constructor);
-    if (currentContexts == null) {
-      DECORATED_PROPERTY_CLASSES.set(target.constructor, {
-        [contextKey]: key,
-      });
-    } else {
-      DECORATED_PROPERTY_CLASSES.set(target.constructor, {
-        ...currentContexts,
-        [contextKey]: key,
-      });
-    }
+    // Define a property on the class, which will later be used on instances of
+    // the component to register them as context providers.
+    const currentContexts = Object.getOwnPropertyDescriptor(
+      target,
+      EMBER_PROVIDE_CONSUME_CONTEXT_KEY,
+    );
+
+    // A class can have multiple @provide decorated properties, we need to
+    // merge the definitions
+    const contextsValue =
+      currentContexts != null
+        ? {
+            ...currentContexts.value,
+            [contextKey]: key,
+          }
+        : {
+            [contextKey]: key,
+          };
+
+    Object.defineProperty(target, EMBER_PROVIDE_CONSUME_CONTEXT_KEY, {
+      value: contextsValue,
+      writable: true,
+      configurable: true,
+    });
   };
 }
 

--- a/ember-provide-consume-context/src/-private/provide-consume-context-container.ts
+++ b/ember-provide-consume-context/src/-private/provide-consume-context-container.ts
@@ -2,32 +2,35 @@ import type { ComponentInstance } from '@glimmer/interfaces';
 import { Stack } from '@glimmer/util';
 import type ContextRegistry from '../context-registry';
 
-// Map of component class that contain @provide decorated properties, with their
-// respective context keys and property names
-export const DECORATED_PROPERTY_CLASSES = new WeakMap<
-  any,
-  Record<keyof ContextRegistry, string>
->();
-// Map of instances of the ContextProvider component, or components that contain
-// @provide decorated properties
-export const PROVIDER_INSTANCES = new WeakMap<any, Record<string, string>>();
+export const EMBER_PROVIDE_CONSUME_CONTEXT_KEY = Symbol.for(
+  'EMBER_PROVIDE_CONSUME_CONTEXT_KEY',
+);
 
-export function trackProviderInstanceContexts(
+export function setContextMetadataOnContextProviderInstance(
   instance: any,
   contextDefinitions: [
     contextKey: keyof ContextRegistry,
     propertyKey: string,
   ][],
 ) {
-  const currentContexts = PROVIDER_INSTANCES.get(instance);
-  if (currentContexts == null) {
-    PROVIDER_INSTANCES.set(instance, Object.fromEntries(contextDefinitions));
-  } else {
-    PROVIDER_INSTANCES.set(instance, {
-      ...currentContexts,
-      ...Object.fromEntries(contextDefinitions),
-    });
-  }
+  const currentContexts = Object.getOwnPropertyDescriptor(
+    instance,
+    EMBER_PROVIDE_CONSUME_CONTEXT_KEY,
+  );
+
+  const contextsValue =
+    currentContexts != null
+      ? {
+          ...currentContexts.value,
+          ...Object.fromEntries(contextDefinitions),
+        }
+      : Object.fromEntries(contextDefinitions);
+
+  Object.defineProperty(instance, EMBER_PROVIDE_CONSUME_CONTEXT_KEY, {
+    value: contextsValue,
+    writable: true,
+    configurable: true,
+  });
 }
 
 interface Contexts {
@@ -71,34 +74,11 @@ export class ProvideConsumeContextContainer {
   }
 
   enter(instance: ComponentInstance): void {
-    const componentDefinitionClass = instance.definition.state;
     const actualComponentInstance = (instance?.state as any)?.component;
 
     if (actualComponentInstance != null) {
-      const isDecorated = DECORATED_PROPERTY_CLASSES.has(
-        componentDefinitionClass,
-      );
-
-      // If this is an instance of a component that contains @provide decorated
-      // properties, add this instance - and the context keys - to the
-      // PROVIDE_INSTANCES map, so that the context values can be set in the
-      // next step
-      if (isDecorated) {
-        const contextKeys = DECORATED_PROPERTY_CLASSES.get(
-          componentDefinitionClass,
-        );
-
-        if (contextKeys != null) {
-          trackProviderInstanceContexts(
-            actualComponentInstance,
-            Object.entries(contextKeys) as [keyof ContextRegistry, string][],
-          );
-        }
-      }
-
-      const isProviderInstance = PROVIDER_INSTANCES.has(
-        actualComponentInstance,
-      );
+      const isProviderInstance =
+        actualComponentInstance[EMBER_PROVIDE_CONSUME_CONTEXT_KEY];
 
       if (isProviderInstance) {
         this.registerProvider(actualComponentInstance);
@@ -131,9 +111,11 @@ export class ProvideConsumeContextContainer {
       }
     }
 
-    const registeredContexts = PROVIDER_INSTANCES.get(provider);
+    const registeredContexts = provider[EMBER_PROVIDE_CONSUME_CONTEXT_KEY];
     if (registeredContexts != null) {
-      Object.entries(registeredContexts).forEach(([contextKey, key]) => {
+      Object.entries(
+        registeredContexts as Record<keyof ContextRegistry, string>,
+      ).forEach(([contextKey, key]) => {
         if (key in provider) {
           providerContexts[contextKey] = {
             instance: provider,

--- a/ember-provide-consume-context/src/-private/provide-consume-context-container.ts
+++ b/ember-provide-consume-context/src/-private/provide-consume-context-container.ts
@@ -18,13 +18,10 @@ export function setContextMetadataOnContextProviderInstance(
     EMBER_PROVIDE_CONSUME_CONTEXT_KEY,
   );
 
-  const contextsValue =
-    currentContexts != null
-      ? {
-          ...currentContexts.value,
-          ...Object.fromEntries(contextDefinitions),
-        }
-      : Object.fromEntries(contextDefinitions);
+  const contextsValue = {
+    ...currentContexts?.value,
+    ...Object.fromEntries(contextDefinitions),
+  };
 
   Object.defineProperty(instance, EMBER_PROVIDE_CONSUME_CONTEXT_KEY, {
     value: contextsValue,

--- a/ember-provide-consume-context/src/components/context-provider.ts
+++ b/ember-provide-consume-context/src/components/context-provider.ts
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { trackProviderInstanceContexts } from '../-private/provide-consume-context-container';
+import { setContextMetadataOnContextProviderInstance } from '../-private/provide-consume-context-container';
 import type ContextRegistry from '../context-registry';
 
 interface ContextProviderSignature<K extends keyof ContextRegistry> {
@@ -18,7 +18,7 @@ export default class ContextProvider<
   constructor(owner: unknown, args: ContextProviderSignature<K>['Args']) {
     super(owner, args);
 
-    trackProviderInstanceContexts(this, [[args.key, 'value']]);
+    setContextMetadataOnContextProviderInstance(this, [[args.key, 'value']]);
   }
 
   get value() {

--- a/test-app/tests/integration/components/decorators-test.ts
+++ b/test-app/tests/integration/components/decorators-test.ts
@@ -63,6 +63,68 @@ module('Integration | Decorators', function (hooks) {
     assert.dom('#content').hasText('1');
   });
 
+  test('a component can provide multiple contexts', async function (assert) {
+    class TestProviderComponent extends Component<{
+      Element: HTMLDivElement;
+      Blocks: {
+        default: [];
+      };
+    }> {
+      @provide('my-test-context-1')
+      get myState1() {
+        return '1';
+      }
+
+      @provide('my-test-context-2')
+      get myState2() {
+        return '2';
+      }
+    }
+
+    setComponentTemplate(
+      // @ts-ignore
+      hbs`{{! @glint-ignore }}
+        <div>{{yield}}</div>
+      `,
+      TestProviderComponent,
+    );
+
+    class TestConsumerComponent extends Component<{
+      Element: HTMLDivElement;
+    }> {
+      @consume('my-test-context-1') contextValue1!: string;
+      @consume('my-test-context-2') contextValue2!: string;
+    }
+
+    setComponentTemplate(
+      // @ts-ignore
+      hbs`{{! @glint-ignore }}
+        <div id="content-1">{{this.contextValue1}}</div>
+        {{! @glint-ignore }}
+        <div id="content-2">{{this.contextValue2}}</div>
+      `,
+      TestConsumerComponent,
+    );
+
+    interface TestContext {
+      TestProviderComponent: typeof TestProviderComponent;
+      TestConsumerComponent: typeof TestConsumerComponent;
+    }
+    (this as unknown as TestContext).TestProviderComponent =
+      TestProviderComponent;
+    (this as unknown as TestContext).TestConsumerComponent =
+      TestConsumerComponent;
+
+    await render<TestContext>(hbs`
+      <this.TestProviderComponent>
+        <this.TestConsumerComponent />
+      </this.TestProviderComponent>
+    `);
+
+    assert.dom('#content-1').hasText('1');
+    assert.dom('#content-2').hasText('2');
+  });
+
   test('the built-in consumer can read context where provider uses decorator', async function (assert) {
     class TestProviderComponent extends Component<{
       Element: HTMLDivElement;
@@ -101,22 +163,32 @@ module('Integration | Decorators', function (hooks) {
     assert.dom('#content').hasText('1');
   });
 
-  test('a consumer updates when provider value changes', async function (assert) {
+  test('a consumer updates when provider values change', async function (assert) {
     class TestProviderComponent extends Component<{
       Element: HTMLDivElement;
       Blocks: {
         default: [];
       };
     }> {
-      @tracked count = 1;
+      @tracked count1 = 1;
+      @tracked count2 = 30;
 
-      @provide('my-test-context')
-      get myState() {
-        return this.count;
+      @provide('my-test-context-1')
+      get myState1() {
+        return this.count1;
       }
 
-      increment = () => {
-        this.count++;
+      @provide('my-test-context-2')
+      get myState2() {
+        return this.count2;
+      }
+
+      increment1 = () => {
+        this.count1++;
+      };
+
+      increment2 = () => {
+        this.count2++;
       };
     }
 
@@ -126,7 +198,11 @@ module('Integration | Decorators', function (hooks) {
         <div>
           <div>
             {{! @glint-ignore }}
-            <button {{on "click" this.increment}} id="increment" type="button">Increment</button>
+            <button {{on "click" this.increment1}} id="increment-1" type="button">Increment 1</button>
+          </div>
+          <div>
+            {{! @glint-ignore }}
+            <button {{on "click" this.increment2}} id="increment-2" type="button">Increment 2</button>
           </div>
 
           <div>
@@ -141,13 +217,16 @@ module('Integration | Decorators', function (hooks) {
     class TestConsumerComponent extends Component<{
       Element: HTMLDivElement;
     }> {
-      @consume('my-test-context') contextValue!: string;
+      @consume('my-test-context-1') contextValue1!: string;
+      @consume('my-test-context-2') contextValue2!: string;
     }
 
     setComponentTemplate(
       // @ts-ignore
       hbs`{{! @glint-ignore }}
-        <div id="content">{{this.contextValue}}</div>
+        <div id="content-1">{{this.contextValue1}}</div>
+        {{! @glint-ignore }}
+        <div id="content-2">{{this.contextValue2}}</div>
       `,
       TestConsumerComponent,
     );
@@ -167,9 +246,14 @@ module('Integration | Decorators', function (hooks) {
       </this.TestProviderComponent>
     `);
 
-    assert.dom('#content').hasText('1');
+    assert.dom('#content-1').hasText('1');
 
-    await click('#increment');
-    assert.dom('#content').hasText('2');
+    await click('#increment-1');
+    assert.dom('#content-1').hasText('2');
+
+    assert.dom('#content-2').hasText('30');
+
+    await click('#increment-2');
+    assert.dom('#content-2').hasText('31');
   });
 });


### PR DESCRIPTION
Closes https://github.com/customerio/ember-provide-consume-context/issues/16

Currently this context implementation might fail if there are multiple copies of this addon present in an app (for example, an addon and the app use different versions of `ember-provide-consume-context`).

This is because, internally, `ember-provide-consume-context` uses cache WeakMaps to save instances of components with `@provide` decorated properties, as well as instances of the `ContextProvider` component. When multiple copies of this addon are present, they use separate WeakMaps, which means a context provider from the app may not be seen in an addon, or the other way around.

As a fix, we'll instead assign context information to the component class or instance directly (using a Symbol key property). This will allow us to check whether a component provides context regardless of which addon instance the component comes from.

For components that use the `@provide` decorator, the property will be defined on the component class definition (the prototype). Instances of this component will then include that property too.
For instances of the `ContextProvider` component, we set the property directly on the instance (the context key comes from a component argument, which means we can't read it before initializing the component to set it on the class definition).

This is a breaking change, please make sure to update your addons and apps at the same time when updating `ember-provide-consume-context`.

Additionally, I'm adding a few more decorator tests to cover more scenarios.