### PR TITLE
Add context provider test helpers

### DIFF
--- a/.changeset/serious-lemons-pull.md
+++ b/.changeset/serious-lemons-pull.md
@@ -1,0 +1,5 @@
+---
+"ember-provide-consume-context": patch
+---
+
+Add context provider test helpers

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -16,6 +16,10 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./test-support": {
+      "types": "./declarations/test-support/index.d.ts",
+      "default": "./dist/test-support/index.js"
+    },
     "./*": {
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"
@@ -56,7 +60,8 @@
     "@glimmer/component": "^1.1.2"
   },
   "peerDependencies": {
-    "ember-source": "^4.8.0 || ^5.0.0"
+    "ember-source": "^4.8.0 || ^5.0.0",
+    "@ember/test-helpers": "^2.9.1 || ^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",
@@ -65,6 +70,7 @@
     "@babel/plugin-transform-class-static-block": "^7.20.0",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/runtime": "^7.17.0",
+    "@ember/test-helpers": "^3.3.0",
     "@embroider/addon-dev": "^4.1.0",
     "@glimmer/interfaces": "^0.84.3",
     "@glimmer/runtime": "^0.84.3",

--- a/ember-provide-consume-context/rollup.config.mjs
+++ b/ember-provide-consume-context/rollup.config.mjs
@@ -27,6 +27,7 @@ export default {
       'index.js',
       'template-registry.js',
       'context-registry.js',
+      'test-support/**/*.js',
     ]),
 
     // These are the modules that should get reexported into the traditional

--- a/ember-provide-consume-context/src/test-support/index.ts
+++ b/ember-provide-consume-context/src/test-support/index.ts
@@ -1,0 +1,57 @@
+import { getContext } from '@ember/test-helpers';
+import type { TestContext } from '@ember/test-helpers';
+import type { ProvideConsumeContextContainer } from '../-private/provide-consume-context-container';
+import type ContextRegistry from '../context-registry';
+
+export function setupRenderWrapper(templateFactory: object) {
+  const context = getContext() as TestContext | undefined;
+  if (context == null) {
+    throw new Error('Could not find test context');
+  }
+
+  if (context.owner == null) {
+    throw new Error('Could not find owner on test context');
+  }
+
+  const { owner } = context;
+
+  // Registers a custom outlet to use in the test, similar to how test-helpers does it:
+  // https://github.com/emberjs/ember-test-helpers/blob/9cec68dc6aa9c0a7a449eb89797eb81299fa727f/addon/addon-test-support/%40ember/test-helpers/setup-rendering-context.ts#L68
+  // Casting "as any" because "unregister" isn't defined on the Owner type, but it does exist.
+  (owner as any).unregister('template:-outlet');
+  owner.register('template:-outlet', templateFactory);
+}
+
+export function provide<
+  T extends keyof ContextRegistry,
+  U extends ContextRegistry[T],
+>(name: T, value: U) {
+  const context = getContext() as TestContext | undefined;
+  if (context?.owner != null) {
+    const { owner } = context;
+
+    // https://github.com/emberjs/ember.js/blob/57073a0e9751d036d4bcfc11d5367e3f6ae751d2/packages/%40ember/-internals/glimmer/lib/renderer.ts#L284
+    // We cast to "any", because Renderer is a private API and isn't easily accessible.
+    // Even if we imported the type, "_runtime" is marked as private,
+    // so we wouldn't be able to access the current runtime or its type.
+    // If Context was implemented in Ember proper, it would have access to those private
+    // APIs, and this wouldn't look quite as illegal anymore.
+    const renderer = owner.lookup('renderer:-dom') as any;
+
+    if (renderer == null) {
+      throw new Error('Could not find "renderer:-dom" on owner');
+    }
+
+    const container = renderer._runtime?.env?.provideConsumeContextContainer as
+      | ProvideConsumeContextContainer
+      | undefined;
+
+    if (container == null) {
+      throw new Error(
+        'Could not find "provideConsumeContextContainer" instance in runtime environment',
+      );
+    }
+
+    container.registerMockProvider(name, value);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@babel/plugin-transform-class-static-block": "^7.20.0",
         "@babel/preset-typescript": "^7.18.6",
         "@babel/runtime": "^7.17.0",
+        "@ember/test-helpers": "^3.3.0",
         "@embroider/addon-dev": "^4.1.0",
         "@glimmer/interfaces": "^0.84.3",
         "@glimmer/runtime": "^0.84.3",
@@ -78,6 +79,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
+        "@ember/test-helpers": "^2.9.1 || ^3.0.0",
         "ember-source": "^4.8.0 || ^5.0.0"
       }
     },
@@ -2352,9 +2354,9 @@
       }
     },
     "node_modules/@ember/test-helpers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-3.2.1.tgz",
-      "integrity": "sha512-DvJSihJPV4xshwEgBrFN4aUVc9m/Y/hVzwcslfSVq/h3dMWCyAj4+agkkdJPQrwBaE+H4IyGNzr555S7bTErEA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-3.3.0.tgz",
+      "integrity": "sha512-HEI28wtjnQuEj9+DstHUEEKPtqPAEVN9AAVr4EifVCd3DyEDy0m6hFT4qbap1WxAIktLja2QXGJg50lVWzZc5g==",
       "dev": true,
       "dependencies": {
         "@ember/test-waiters": "^3.0.2",
@@ -2362,6 +2364,7 @@
         "@simple-dom/interface": "^1.4.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^3.0.8",
+        "dom-element-descriptors": "^0.5.0",
         "ember-auto-import": "^2.6.0",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.2.0"
@@ -10093,6 +10096,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-element-descriptors": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/dom-element-descriptors/-/dom-element-descriptors-0.5.0.tgz",
+      "integrity": "sha512-CVzntLid1oFVHTKdTp/Qu7Kz+wSm8uO30TSQyAJ6n4Dz09yTzVQn3S1oRhVhUubxdMuKs1DjDqt88pubHagbPw==",
+      "dev": true
+    },
     "node_modules/domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -13489,7 +13498,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24540,7 +24548,7 @@
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
         "@ember/string": "^3.0.1",
-        "@ember/test-helpers": "^3.2.1",
+        "@ember/test-helpers": "^3.3.0",
         "@embroider/test-setup": "^3.0.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -29,10 +29,9 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "ember-provide-consume-context": "*",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
-    "@ember/test-helpers": "^3.2.1",
+    "@ember/test-helpers": "^3.3.0",
     "@embroider/test-setup": "^3.0.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
@@ -78,6 +77,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-page-title": "^7.0.0",
+    "ember-provide-consume-context": "*",
     "ember-qunit": "^8.0.2",
     "ember-resolver": "^10.0.0",
     "ember-source": "~4.12.2",

--- a/test-app/tests/integration/components/test-support-test.ts
+++ b/test-app/tests/integration/components/test-support-test.ts
@@ -1,0 +1,95 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import {
+  setupRenderWrapper,
+  provide,
+} from 'ember-provide-consume-context/test-support';
+
+module('Integration | Provider test helpers', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('provide in beforeEach', function (hooks) {
+    hooks.beforeEach(function (this) {
+      provide('my-test-context', '1');
+    });
+
+    test('can read context provided by "provide" test helper', async function (assert) {
+      await render(hbs`
+        <ContextConsumer @key="my-test-context" as |count|>
+          <div id="content">{{count}}</div>
+        </ContextConsumer>
+      `);
+
+      assert.dom('#content').hasText('1');
+    });
+
+    test('can override "provide" context with a provider component', async function (assert) {
+      await render(hbs`
+        <ContextProvider @key="my-test-context" @value="2">
+          <ContextConsumer @key="my-test-context" as |count|>
+            <div id="content">{{count}}</div>
+          </ContextConsumer>
+        </ContextProvider>
+      `);
+
+      assert.dom('#content').hasText('2');
+    });
+  });
+
+  module('setupRenderWrapper in beforeEach', function (hooks) {
+    hooks.beforeEach(function (this) {
+      setupRenderWrapper(
+        hbs`<ContextProvider @key="my-test-context" @value="3">{{outlet}}</ContextProvider>`,
+      );
+    });
+
+    test('can read context provided by "setupRenderWrapper" test helper', async function (assert) {
+      await render(hbs`
+        <ContextConsumer @key="my-test-context" as |count|>
+          <div id="content">{{count}}</div>
+        </ContextConsumer>
+      `);
+
+      assert.dom('#content').hasText('3');
+    });
+
+    test('can override "setupRenderWrapper" context with a provider component', async function (assert) {
+      await render(hbs`
+        <ContextProvider @key="my-test-context" @value="4">
+          <ContextConsumer @key="my-test-context" as |count|>
+            <div id="content">{{count}}</div>
+          </ContextConsumer>
+        </ContextProvider>
+      `);
+
+      assert.dom('#content').hasText('4');
+    });
+  });
+
+  test('can read context provided by "provide" test helper', async function (assert) {
+    provide('my-test-context', '5');
+    await render(hbs`
+      <ContextConsumer @key="my-test-context" as |count|>
+        <div id="content">{{count}}</div>
+      </ContextConsumer>
+    `);
+
+    assert.dom('#content').hasText('5');
+  });
+
+  test('can read context provided by "setupRenderWrapper" test helper', async function (assert) {
+    setupRenderWrapper(
+      hbs`<ContextProvider @key="my-test-context" @value="6">{{outlet}}</ContextProvider>`,
+    );
+
+    await render(hbs`
+      <ContextConsumer @key="my-test-context" as |count|>
+        <div id="content">{{count}}</div>
+      </ContextConsumer>
+    `);
+
+    assert.dom('#content').hasText('6');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/customerio/ember-provide-consume-context/issues/18

This adds two test helpers to make it easier to define context values in tests.

`provide` can be used to define a value under a context key.

`setupRenderWrapper` can be used to render an entire component to wrap the contents rendered by `@ember/test-helpers` `render`. This one overrides some `@ember/test-helpers` internals, and should probably just be an API exposed by that library at some point.