### PR TITLE
Fix test-support TypeScript import

### DIFF
--- a/.changeset/tasty-snails-pull.md
+++ b/.changeset/tasty-snails-pull.md
@@ -1,0 +1,5 @@
+---
+"ember-provide-consume-context": patch
+---
+
+Fix test-support typesVersions

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -32,7 +32,7 @@
         "./declarations/test-support/index.d.ts"
       ],
       "*": [
-        "declarations/*"
+        "./declarations/*"
       ]
     }
   },

--- a/ember-provide-consume-context/package.json
+++ b/ember-provide-consume-context/package.json
@@ -28,6 +28,9 @@
   },
   "typesVersions": {
     "*": {
+      "test-support": [
+        "./declarations/test-support/index.d.ts"
+      ],
       "*": [
         "declarations/*"
       ]


### PR DESCRIPTION
Closes https://github.com/customerio/ember-provide-consume-context/issues/24

Fixes the `typesVersions` declaration in package.json so that the test helpers can be correctly imported in TypeScript projects.