### PR TITLE
Make `consume` and `ContextConsumer` return `undefined` rather than `null`

### DIFF
--- a/.changeset/red-cars-sniff.md
+++ b/.changeset/red-cars-sniff.md
@@ -1,0 +1,6 @@
+---
+"ember-provide-consume-context": minor
+"test-app": patch
+---
+
+Make `consume` and `ContextConsumer` return `undefined` rather than `null`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 ## Building the addon
 
 - `cd ember-provide-consume-context`
-- `npm build`
+- `npm run build`
 
 ## Running tests
 

--- a/ember-provide-consume-context/src/-private/decorators.ts
+++ b/ember-provide-consume-context/src/-private/decorators.ts
@@ -31,12 +31,12 @@ export function consume<K extends keyof ContextRegistry>(
 ): PropertyDecorator {
   return function decorator() {
     return {
-      get(): ContextRegistry[K] | null | undefined {
+      get(): ContextRegistry[K] | undefined {
         if (hasContext(this, contextKey)) {
           return getContextValue(this, contextKey);
         }
 
-        return null;
+        return undefined;
       },
     };
   };

--- a/ember-provide-consume-context/src/components/context-consumer.ts
+++ b/ember-provide-consume-context/src/components/context-consumer.ts
@@ -8,18 +8,18 @@ interface ContextConsumerSignature<K extends keyof ContextRegistry> {
     defaultValue?: ContextRegistry[K];
   };
   Blocks: {
-    default: [ContextRegistry[K] | null];
+    default: [ContextRegistry[K] | undefined];
   };
 }
 
 export default class ContextConsumer<
   K extends keyof ContextRegistry,
 > extends Component<ContextConsumerSignature<K>> {
-  get contextValue(): ContextRegistry[K] | null {
+  get contextValue(): ContextRegistry[K] | undefined {
     if (hasContext(this, this.args.key)) {
       return getContextValue(this, this.args.key);
     }
 
-    return this.args.defaultValue ?? null;
+    return this.args.defaultValue;
   }
 }

--- a/test-app/app/helpers/eq.ts
+++ b/test-app/app/helpers/eq.ts
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+
+function eq([a, b]: [unknown, unknown]): boolean {
+  return a === b;
+}
+
+const eqHelper = helper(eq);
+
+export default eqHelper;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    eq: typeof eqHelper;
+  }
+}

--- a/test-app/tests/integration/components/built-in-components-test.ts
+++ b/test-app/tests/integration/components/built-in-components-test.ts
@@ -23,6 +23,16 @@ module('Integration | Built-in components', function (hooks) {
     this.testContext = testContext;
   });
 
+  test('consuming a non-existent context returns `undefined`', async function (assert) {
+    await render(hbs`
+      <ContextConsumer @key="my-test-context" as |count|>
+        <div id="content">{{if (eq count undefined) "undefined" "other"}}</div>
+      </ContextConsumer>
+    `);
+
+    assert.dom('#content').hasText('undefined');
+  });
+
   test('a consumer can read context', async function (assert) {
     await render(hbs`
       <ContextProvider @key="my-test-context" @value="5">

--- a/test-app/tests/integration/components/decorators-test.ts
+++ b/test-app/tests/integration/components/decorators-test.ts
@@ -10,6 +10,32 @@ import { tracked } from '@glimmer/tracking';
 module('Integration | Decorators', function (hooks) {
   setupRenderingTest(hooks);
 
+  test('consuming a non-existent context returns `undefined`', async function (assert) {
+    class TestConsumerComponent extends Component<{
+      Element: HTMLDivElement;
+    }> {
+      @consume('my-test-context') contextValue: string | undefined;
+    }
+
+    setComponentTemplate(
+      // @ts-ignore
+      hbs`{{! @glint-ignore }}
+        <div id="content">{{if (eq this.contextValue undefined) "undefined" "other"}}</div>
+      `,
+      TestConsumerComponent,
+    );
+
+    interface TestContext {
+      TestConsumerComponent: typeof TestConsumerComponent;
+    }
+    (this as unknown as TestContext).TestConsumerComponent =
+      TestConsumerComponent;
+
+    await render<TestContext>(hbs`<this.TestConsumerComponent />`);
+
+    assert.dom('#content').hasText('undefined');
+  });
+
   test('a consumer can read context', async function (assert) {
     class TestProviderComponent extends Component<{
       Element: HTMLDivElement;


### PR DESCRIPTION
Fixes #29 

cc @kevinkucharczyk

I'm not sure I've done the change correctly - running `npm lint` locally seems to lead to a lot of TypeScript errors which I'm unsure how to fix. Please take a look and let me know if I've done something wrong.