### PR TITLE
Register contexts at construct time

### DIFF
--- a/.changeset/chilly-cameras-greet.md
+++ b/.changeset/chilly-cameras-greet.md
@@ -1,0 +1,5 @@
+---
+"ember-provide-consume-context": minor
+---
+
+Register contexts at construct time

--- a/ember-provide-consume-context/src/-private/@glimmer/opcodes.ts
+++ b/ember-provide-consume-context/src/-private/@glimmer/opcodes.ts
@@ -7,6 +7,7 @@
 // This is safe, because the opcodes should be stable.
 // https://github.com/glimmerjs/glimmer-vm/blob/68d371bdccb41bc239b8f70d832e956ce6c349d8/packages/%40glimmer/vm/lib/opcodes.ts#L196
 export const enum Op {
+  CreateComponent = 87,
   GetComponentSelf = 90,
   DidRenderLayout = 100,
 }

--- a/ember-provide-consume-context/src/-private/override-glimmer-runtime-classes.ts
+++ b/ember-provide-consume-context/src/-private/override-glimmer-runtime-classes.ts
@@ -31,6 +31,13 @@ function overrideVM(runtime: any) {
     try {
       const { type, op1 } = opcode;
 
+      if (type === Op.CreateComponent) {
+        // Let the container know we're instantiating a new component
+        this.env.provideConsumeContextContainer?.createComponent();
+        // No need to register "updateWith", a component only instantiates
+        // once, and we don't need to run any further updates
+      }
+
       if (type === Op.GetComponentSelf) {
         // Get the component instance from the VM
         // (that's the VM's component instance, not the Glimmer Component one)

--- a/ember-provide-consume-context/src/-private/utils.ts
+++ b/ember-provide-consume-context/src/-private/utils.ts
@@ -29,7 +29,7 @@ export function getProvider(owner: any, contextKey: keyof ContextRegistry) {
     return null;
   }
 
-  const contextsObject = provideConsumeContextContainer.contexts.get(owner);
+  const contextsObject = provideConsumeContextContainer.contextsFor(owner);
   return contextsObject?.[contextKey];
 }
 


### PR DESCRIPTION
This PR makes the addon register context when components get instantiated, rather than on first **render**.

This has two benefits:
- components can initialize state that depends on parent contexts without having to wait for the first render
- a component can `consume` and `provide` the same context key without infinite reference errors: `consume` would read the existing context "above" the component, while `provide` would provide a new context to any nested children