### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
       - name: Install Dependencies
         run: npm ci
-      - uses: kategengler/put-built-npm-package-contents-on-branch@v2.0.0
+      - uses: kategengler/put-built-npm-package-contents-on-branch@5b33924ea713bcde29273ef55bac7e4142a7b917 # v2.0.0
         with:
           branch: dist
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@dafcd08ca059722e5ab7b05b4069899018ee94c8 # v1.4.10
         with:
           version: npm run version
           publish: npm run release


### PR DESCRIPTION
REF: [DX-516](https://linear.app/customerio/issue/DX-516/update-all-github-action-libraries-to-use-sha-instead-of-version) Pins GitHub Actions as part of DX-516.