### PR TITLE
DX-809 update to use preferred OIDC for npm publish in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
-# PR test publish to confirm OIDC is configured correctly
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   id-token: write
@@ -31,13 +33,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
-      - name: Set test version
-        working-directory: ember-provide-consume-context
-        run: npm version 0.0.0-test-oidc --no-git-tag-version
-
-      - name: Publish to npm
-        working-directory: ember-provide-consume-context
-        run: npm publish --tag test-oidc
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@dafcd08ca059722e5ab7b05b4069899018ee94c8 # v1.4.10
+        with:
+          version: npm run version
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the release GitHub Actions workflow to use OIDC for npm publish, Node 20, and latest action versions.
> 
> - **CI/CD — `./github/workflows/release.yml`**:
>   - Switch to OIDC-based publish: add `permissions` (including `id-token: write`), set npm `registry-url`, install npm `11.5.1`, and remove `NPM_TOKEN`.
>   - Upgrade runtime/tooling: Node `18` → `20`; `actions/checkout` and `actions/setup-node` `v3` → `v4`.
>   - Configure job `environment: release`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94a881d16a222c3e42013e7b54e8ea724b444129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->